### PR TITLE
[Rahul] | BAH-3005 | Fix. Hardcoded UTC To IST Conversion

### DIFF
--- a/openmrs/apps/reports/sql/clinicVisits.sql
+++ b/openmrs/apps/reports/sql/clinicVisits.sql
@@ -4,10 +4,10 @@ SELECT
   floor(DATEDIFF(DATE(v.date_started), p.birthdate) / 365)                  AS "Age",
   DATE_FORMAT(p.birthdate, "%d-%b-%Y")                                      AS "Birthdate",
   p.gender                                                                  AS "Gender",
-  DATE_FORMAT(CONVERT_TZ(p.date_created,'+00:00','+5:30'), "%d-%b-%Y")      AS "Patient Created Date",
+  DATE_FORMAT(p.date_created, "%d-%b-%Y")                                   AS "Patient Created Date",
   vt.name                                                                   AS "Visit type",
-  DATE_FORMAT(CONVERT_TZ(v.date_started,'+00:00','+5:30'), "%d-%b-%Y")      AS "Date started",
-  DATE_FORMAT(CONVERT_TZ(v.date_stopped,'+00:00','+5:30'), "%d-%b-%Y")      AS "Date stopped",
+  DATE_FORMAT(v.date_started, "%d-%b-%Y")                                   AS "Date started",
+  DATE_FORMAT(v.date_stopped, "%d-%b-%Y")                                   AS "Date stopped",
   GROUP_CONCAT(DISTINCT(IF(pat.name = "phoneNumber",pa.value, NULL)))       AS "Phone number",
   paddress.city_village                                                     AS "City/Village",
   paddress.state_province                                                   AS "State",
@@ -24,5 +24,5 @@ FROM visit v
   LEFT OUTER JOIN person_attribute pa ON pa.person_id = p.person_id AND pa.voided is FALSE
   LEFT OUTER JOIN person_attribute_type pat ON pat.person_attribute_type_id = pa.person_attribute_type_id AND pat.retired is FALSE
   WHERE v.voided is FALSE
-  AND cast(CONVERT_TZ(v.date_started,'+00:00','+5:30') AS DATE) BETWEEN '#startDate#' AND '#endDate#'
+  AND cast(v.date_started AS DATE) BETWEEN '#startDate#' AND '#endDate#'
 GROUP BY v.visit_id;

--- a/openmrs/apps/reports/sql/diagnosisCount.sql
+++ b/openmrs/apps/reports/sql/diagnosisCount.sql
@@ -16,7 +16,7 @@ from
    JOIN person on diagnosis.person_id = person.person_id AND person.voided = FALSE
    JOIN concept_view AS cv
    ON cv.concept_id = diagnosis.value_coded AND cv.concept_class_name = 'Diagnosis' AND
-   cast(CONVERT_TZ(diagnosis.obs_datetime,'+00:00','+5:30') AS DATE) BETWEEN '#startDate#' AND '#endDate#' 
+   cast(diagnosis.obs_datetime AS DATE) BETWEEN '#startDate#' AND '#endDate#' 
    AND diagnosis.voided = 0 AND diagnosis.obs_group_id IN (
 			SELECT DISTINCT certaintyObs.obs_id from (
       	  		SELECT DISTINCT parent.obs_id
@@ -40,7 +40,7 @@ from
    FROM conditions patient_conditions
    JOIN person on patient_conditions.patient_id = person.person_id
    WHERE patient_conditions.clinical_status = 'ACTIVE'
-   AND cast(CONVERT_TZ(patient_conditions.date_created,'+00:00','+5:30') AS DATE) BETWEEN '#startDate#' AND '#endDate#' 
+   AND cast(patient_conditions.date_created AS DATE) BETWEEN '#startDate#' AND '#endDate#' 
    AND patient_conditions.voided = FALSE AND person.voided = FALSE group by patient_conditions.condition_coded
    )) as diagnosisObs
 

--- a/openmrs/apps/reports/sql/followUp.sql
+++ b/openmrs/apps/reports/sql/followUp.sql
@@ -5,7 +5,7 @@ SELECT DISTINCT
 	 TIMESTAMPDIFF(YEAR, p.birthdate, CURDATE()) AS "Age",
 	 p.gender AS 'Gender',
 	 pMobile.phoneNumber AS 'Phone Number',
-     DATE_FORMAT(CONVERT_TZ(start_date_time,'+00:00','+5:30'), "%d/%m/%Y %h:%i %p") AS 'Appointment Time'
+     DATE_FORMAT(start_date_time, "%d/%m/%Y %h:%i %p") AS 'Appointment Time'
 FROM patient_appointment pa
    JOIN appointment_service app_service
     ON app_service.appointment_service_id = pa.appointment_service_id AND app_service.voided IS FALSE

--- a/openmrs/apps/reports/sql/missedAppointments.sql
+++ b/openmrs/apps/reports/sql/missedAppointments.sql
@@ -5,7 +5,7 @@ SELECT DISTINCT
 		IF(pn.family_name IS NULL OR pn.family_name = '', '', pn.family_name)) AS "Patient Name", 
 	 TIMESTAMPDIFF(YEAR, p.birthdate, CURDATE()) AS "Age", 
 	 p.gender AS 'Gender', 
-	 DATE_FORMAT(convert_tz(start_date_time,'+00:00','+05:30'), "%d/%m/%Y %h:%i %p") AS 'Missed Appointment Date', 
+	 DATE_FORMAT(start_date_time, "%d/%m/%Y %h:%i %p") AS 'Missed Appointment Date', 
 	 app_service.name AS 'Missed Appointment Service', 
 	 concat(ppn.given_name, ' ', IF(ppn.family_name IS NULL OR ppn.family_name = '', '', ppn.family_name)) AS "Provider Name", 
 	 pMobile.phoneNumber AS 'Phone Number', 
@@ -28,4 +28,4 @@ FROM patient_appointment pa
 	LEFT JOIN provider pr ON pr.provider_id = pap.provider_id AND (pr.retired IS FALSE or pr.retired IS null) 
 	LEFT JOIN person pp ON pp.person_id = pr.person_id AND pp.voided IS FALSE 
     LEFT JOIN person_name ppn ON ppn.person_id = pp.person_id AND ppn.voided IS FALSE 
-WHERE pa.status = 'Missed' and cast(CONVERT_TZ(pa.start_date_time,'+00:00','+5:30') AS DATE) BETWEEN '#startDate#' AND '#endDate#' ORDER BY pa.start_date_time DESC; 
+WHERE pa.status = 'Missed' and cast(pa.start_date_time AS DATE) BETWEEN '#startDate#' AND '#endDate#' ORDER BY pa.start_date_time DESC; 

--- a/openmrs/apps/reports/sql/notifiableDiseases.sql
+++ b/openmrs/apps/reports/sql/notifiableDiseases.sql
@@ -5,7 +5,7 @@ SELECT
     concat(pn.given_name, " ", ifnull(pn.family_name, ""))                              AS "Patient Name",
     pa.value                                                                            AS 'Phone Number',
     cn.name                                                                             AS 'Diagnosis',
-    DATE_FORMAT(CONVERT_TZ(diagnosisObs.obs_datetime,'+00:00','+5:30'), "%d-%b-%Y")     AS "Date of Diagnosis"
+    DATE_FORMAT(diagnosisObs.obs_datetime, "%d-%b-%Y")                                  AS "Date of Diagnosis"
 FROM patient pt
          JOIN person p ON p.person_id = pt.patient_id AND p.voided is FALSE
          JOIN person_name pn ON pn.person_id = p.person_id AND pn.voided is FALSE
@@ -25,7 +25,7 @@ FROM patient pt
                        diagnosis.obs_datetime from obs AS diagnosis
                        JOIN concept_view AS cv
                             ON cv.concept_id = diagnosis.value_coded AND cv.concept_class_name = 'Diagnosis' AND
-                               cast(CONVERT_TZ(diagnosis.obs_datetime,'+00:00','+5:30') AS DATE) BETWEEN '#startDate#' AND '#endDate#'  AND diagnosis.voided = 0
+                               cast(diagnosis.obs_datetime AS DATE) BETWEEN '#startDate#' AND '#endDate#'  AND diagnosis.voided = 0
                                 AND diagnosis.obs_group_id IN (
                                     SELECT DISTINCT certaintyObs.obs_id from (
                                                                               SELECT DISTINCT parent.obs_id
@@ -47,7 +47,7 @@ FROM patient pt
                            patient_conditions.date_created AS obs_datetime
                     FROM conditions patient_conditions
                     WHERE patient_conditions.clinical_status = 'ACTIVE'
-                          AND cast(CONVERT_TZ(patient_conditions.date_created,'+00:00','+5:30') AS DATE) BETWEEN '#startDate#' AND '#endDate#'                                                                                                                                                                        AND voided = FALSE
+                          AND cast(patient_conditions.date_created AS DATE) BETWEEN '#startDate#' AND '#endDate#'                                                                                                                                                                        AND voided = FALSE
                ) as diagnosisObs on diagnosisObs.person_id = p.person_id
          JOIN concept_name notifiableDisease on notifiableDisease.name = 'Notifiable Disease'
               AND notifiableDisease.concept_name_type = 'FULLY_SPECIFIED' AND notifiableDisease.voided = false

--- a/openmrs/apps/reports/sql/registeredPatients.sql
+++ b/openmrs/apps/reports/sql/registeredPatients.sql
@@ -4,7 +4,7 @@ SELECT
   concat(pn.given_name, " ", ifnull(pn.family_name, ""))                                                                                  AS "Patient Name",
   floor(DATEDIFF(NOW(), p.birthdate) / 365)                                                                                               AS "Age",
   p.gender                                                                                                                                AS "Gender",
-  DATE_FORMAT(CONVERT_TZ(pt.date_created,'+00:00','+5:30'), "%d-%b-%Y")                                                                   AS "Registration Date"
+  DATE_FORMAT(pt.date_created, "%d-%b-%Y")                                                                                                AS "Registration Date"
 
 FROM patient pt
   JOIN person p ON p.person_id = pt.patient_id AND p.voided is FALSE
@@ -21,4 +21,4 @@ FROM patient pt
 		ON pt.patient_id = extraIdentifier.patient_id
   CROSS JOIN (SELECT @rownum := 0) AS dummy
   WHERE pt.voided is FALSE
-  AND cast(CONVERT_TZ(pt.date_created,'+00:00','+5:30') AS DATE) BETWEEN '#startDate#' AND '#endDate#';
+  AND cast(pt.date_created AS DATE) BETWEEN '#startDate#' AND '#endDate#';

--- a/openmrs/apps/reports/sql/visitCount.sql
+++ b/openmrs/apps/reports/sql/visitCount.sql
@@ -8,4 +8,4 @@ select  ifnull(sum(if(visit_type_name='OPD' and date_started=date_created,1,0)),
         (select v.visit_id, vt.name as visit_type_name, p.person_id, date(v.date_started) as date_started, date(p.date_created) as date_created from visit v
             inner join person p on p.person_id=v.patient_id
             inner join visit_type vt on vt.visit_type_id=v.visit_type_id
-            where cast(CONVERT_TZ(v.date_started,'+00:00','+5:30') as date) between '#startDate#' and '#endDate#') as raw_result;
+            where cast(v.date_started as date) between '#startDate#' and '#endDate#') as raw_result;


### PR DESCRIPTION
Jira Card -> https://bahmni.atlassian.net/browse/BAH-3005

As part of card BAH-3005, it was noticed that all docker containers use UTC as their default timezone and to fix this we have added a TZ environment variable to [Bahmni/bahmni-docker](https://github.com/Bahmni/bahmni-docker/pull/45). It was noticed that the [BahmniIndiaDistro/clinic-config/openmrs/apps/reports/sql](https://github.com/BahmniIndiaDistro/clinic-config/blob/403fe2c812d652eafe1ff9eef9b63dd65aab7395/openmrs/apps/reports/sql/clinicVisits.sql#L7) had some hardcoded UTC To IST Conversion, which would break once the env variable is put to use. In this PR, we have fixed this by removing the hardcoded UTC to IST conversion.